### PR TITLE
Dnd implementation

### DIFF
--- a/api/handlers/move_file.go
+++ b/api/handlers/move_file.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+type MoveRequest struct {
+	SourcePath string `json:"sourcePath"`
+	DestPath 	 string `json:"destPath"`
+}
+
+func MoveHandler(w http.ResponseWriter, r *http.Request) {
+	var req MoveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request payload", http.StatusBadRequest)
+		return
+	}
+
+	srcFull := filepath.Join(BaseDir, filepath.Clean(req.SourcePath))
+	destDir := filepath.Join(BaseDir, filepath.Clean(req.DestPath))
+
+	info, err := os.Stat(destDir)
+	if err != nil {
+		http.Error(w, "destination not found", http.StatusBadRequest)
+		return
+	}
+	if !info.IsDir() {
+		http.Error(w, "destination is not a folder", http.StatusBadRequest)
+		return
+	}
+
+	newFull := filepath.Join(destDir, filepath.Base(srcFull))
+
+	if err := os.Rename(srcFull, newFull); err != nil {
+		msg := fmt.Sprintf("could not move item: %v", err)
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/api/handlers/rename_item.go
+++ b/api/handlers/rename_item.go
@@ -10,8 +10,9 @@ import (
 
 type RenameItemRequest struct {
 	ParentPath string `json:"parentPath"`
-	CurrFile string `json:"currFile"`
+	CurrName string `json:"currentName"`
 	NewName string `json:"newName"`
+	Type string `json:"type"`
 }
 
 func RenameItemHandler(w http.ResponseWriter, r *http.Request) {
@@ -22,13 +23,16 @@ func RenameItemHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cleanParent := filepath.Clean(req.ParentPath)
+	if filepath.IsAbs(cleanParent) {
+		cleanParent = strings.TrimPrefix(cleanParent, string(filepath.Separator))
+	}
 	if strings.Contains(cleanParent, "..") {
 		http.Error(w, "Invalid JSON payload", http.StatusBadRequest)
 		return
 	}
 
 	newPath := filepath.Join(BaseDir, cleanParent, req.NewName)
-	currPath := filepath.Join(BaseDir, cleanParent, req.CurrFile)
+	currPath := filepath.Join(BaseDir, cleanParent, req.CurrName)
 
 	if err := os.Rename(currPath, newPath); err != nil {
 		http.Error(w, "Could not rename item" + err.Error(), http.StatusInternalServerError)

--- a/api/main.go
+++ b/api/main.go
@@ -21,6 +21,7 @@ func main() {
 	r.HandleFunc("/api/download", nest.DownloadHandler).Methods("GET")
 	r.HandleFunc("/api/rename", nest.RenameItemHandler).Methods("POST")
 	r.HandleFunc("/api/delete", nest.DeleteItemHandler).Methods("DELETE")
+	r.HandleFunc("/api/move", nest.MoveHandler).Methods("POST")
 
 	corsOpts := handlers.CORS(
 		handlers.AllowedOrigins([]string{"http://localhost:3000"}),

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,38 @@
     "": {
       "dependencies": {
         "@szhsin/react-menu": "^4.4.1",
+        "react-dnd": "^16.0.1",
+        "react-dnd-html5-backend": "^16.0.1",
         "react-dropzone": "^14.3.8",
         "react-toastify": "^11.0.5"
       }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@react-dnd/asap": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-5.0.2.tgz",
+      "integrity": "sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-4.0.2.tgz",
+      "integrity": "sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz",
+      "integrity": "sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==",
+      "license": "MIT"
     },
     "node_modules/@szhsin/react-menu": {
       "version": "4.4.1",
@@ -41,6 +70,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/dnd-core": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-16.0.1.tgz",
+      "integrity": "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/asap": "^5.0.1",
+        "@react-dnd/invariant": "^4.0.1",
+        "redux": "^4.2.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/file-selector": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
@@ -51,6 +97,15 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
       }
     },
     "node_modules/js-tokens": {
@@ -99,6 +154,45 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dnd": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
+      "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/invariant": "^4.0.1",
+        "@react-dnd/shallowequal": "^4.0.1",
+        "dnd-core": "^16.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz",
+      "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
+      "license": "MIT",
+      "dependencies": {
+        "dnd-core": "^16.0.1"
       }
     },
     "node_modules/react-dom": {
@@ -158,6 +252,15 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/scheduler": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
     "@szhsin/react-menu": "^4.4.1",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-dropzone": "^14.3.8",
     "react-toastify": "^11.0.5"
   }

--- a/ui/src/components/Common/BreadcrumbItem/BreadcumbItem.jsx
+++ b/ui/src/components/Common/BreadcrumbItem/BreadcumbItem.jsx
@@ -1,0 +1,40 @@
+import { useDrop } from "react-dnd";
+
+const BreadcrumbItem = ({
+  label,
+  path,
+  isLast,
+  onNavigate,
+  onDrop
+}) => {
+  const [{ isOver, canDrop }, dropRef] = useDrop({
+    accept: 'ITEM',
+    canDrop: dragged => dragged.parent !== path,
+    drop: async (dragged) => onDrop(dragged.path, path),
+    collect: monitor => ({
+      isOver: monitor.isOver({ shallow: true }),
+      canDrop: monitor.canDrop(),
+    }),
+  });
+
+  return (
+    <li
+      ref={dropRef}
+      className={`breadcrumb-item ${isLast ? 'active' : ''} ${!isLast && isOver && canDrop ? 'border-primary' : 'border-white'} px-1 border rounded`}
+      aria-current={isLast ? 'page' : undefined}
+    >
+      {isLast ? (
+        label
+      ) : (
+          <button
+            className="btn btn-link p-0 text-decoration-none"
+            onClick={onNavigate}
+          >
+            {label}
+          </button>
+        )}
+    </li>
+  )
+}
+
+export default BreadcrumbItem;

--- a/ui/src/components/Common/FormModal/FormModal.jsx
+++ b/ui/src/components/Common/FormModal/FormModal.jsx
@@ -6,6 +6,8 @@ const FormModal = ({
   confirmText,
   onConfirm,
   onCancel,
+  confirmColor = "primary",
+  cancelColor = "danger",
   children,
 }) => {
   const { t } = useTranslation();
@@ -22,12 +24,12 @@ const FormModal = ({
         <div className="d-flex justify-content-end mt-4">
           <button
             type="button"
-            className="btn btn-danger me-2"
+            className={`btn btn-${cancelColor} me-2`}
             onClick={onCancel}
           >
             {t('cancel')}
           </button>
-          <button type="submit" className="btn btn-primary">
+          <button type="submit" className={`btn btn-${confirmColor}`}>
             {confirmText}
           </button>
         </div>

--- a/ui/src/components/Common/FormModal/FormModal.jsx
+++ b/ui/src/components/Common/FormModal/FormModal.jsx
@@ -14,8 +14,7 @@ const FormModal = ({
     <ModalOverlay title={title} onClose={onCancel}>
       <form
         onSubmit={e => {
-          e.preventDefault();
-          onConfirm();
+          onConfirm(e);
         }}
         className="w-100"
       >

--- a/ui/src/components/Common/ItemCard/ItemCard.jsx
+++ b/ui/src/components/Common/ItemCard/ItemCard.jsx
@@ -35,7 +35,8 @@ const ItemCard = ({
     drop: async dragged => {
       try {
         await apiClient.moveItem(dragged.path, item.path);
-        onDropSuccess && onDropSuccess();
+        onDropSuccess?.();
+        toast.success(t('success.move'));
       } catch (err) {
         console.error(err);
         toast.error(t('error.move'));

--- a/ui/src/components/Common/ItemCard/ItemCard.jsx
+++ b/ui/src/components/Common/ItemCard/ItemCard.jsx
@@ -5,6 +5,7 @@ import { faFolder } from "@fortawesome/free-solid-svg-icons";
 import { selectFileIcon } from "../../DashboardComponents/ShowItems/FileIcons";
 import { toast } from 'react-toastify';
 import { useTranslation } from 'react-i18next';
+import { isDescendant } from '../../../utils/pathUtils';
 
 import ItemType from "../../Types/itemType";
 import apiClient from '../../../utils/apiClient';
@@ -27,7 +28,10 @@ const ItemCard = ({
 
   const [{ isOver, canDrop }, drop] = useDrop({
     accept: 'ITEM',
-    canDrop: dragged => dragged.path !== item.path && type === ItemType.FOLDER,
+    canDrop: dragged =>
+      type === ItemType.FOLDER &&
+      dragged.path !== item.path &&
+      !isDescendant(dragged.path, item.path),
     drop: async dragged => {
       try {
         await apiClient.moveItem(dragged.path, item.path);

--- a/ui/src/components/Common/ItemCard/ItemCard.jsx
+++ b/ui/src/components/Common/ItemCard/ItemCard.jsx
@@ -64,7 +64,12 @@ const ItemCard = ({
       }}
       style={{
         opacity: isDragging ? 0.5 : 1,
-        background: isOver && canDrop ? 'rgba(0, 123, 255, 0.1)' : '',
+        border: isOver && canDrop
+          ? '2px dashed #007bff'
+          : '1px solid #dee2e6',
+        boxShadow: isOver && canDrop
+          ? '0 0 8px rgba(0,123,255,0.5)'
+          : 'none',
         cursor: 'move'
       }}
       ref={ref}

--- a/ui/src/components/Common/ItemCard/ItemCard.jsx
+++ b/ui/src/components/Common/ItemCard/ItemCard.jsx
@@ -1,19 +1,53 @@
+import { useRef } from 'react';
+import { useDrag, useDrop } from 'react-dnd';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFolder } from "@fortawesome/free-solid-svg-icons";
 import { selectFileIcon } from "../../DashboardComponents/ShowItems/FileIcons";
+import { toast } from 'react-toastify';
+import { useTranslation } from 'react-i18next';
+
 import ItemType from "../../Types/itemType";
+import apiClient from '../../../utils/apiClient';
 
 const ItemCard = ({
   item,
   type,
   onDoubleClick,
   onContextMenu,
-  onDragStart,
+  onDropSuccess,
   getDisplayName
 }) => {
+  const ref = useRef(null);
+  const { t } = useTranslation();
+  const [{ isDragging }, drag] = useDrag({
+    type: 'ITEM',
+    item: { path: item.path, isDirectory: type === ItemType.FOLDER, name: getDisplayName(item.name), iconType: type },
+    collect: monitor => ({ isDragging: monitor.isDragging() }),
+  });
+
+  const [{ isOver, canDrop }, drop] = useDrop({
+    accept: 'ITEM',
+    canDrop: dragged => dragged.path !== item.path && type === ItemType.FOLDER,
+    drop: async dragged => {
+      try {
+        await apiClient.moveItem(dragged.path, item.path);
+        onDropSuccess && onDropSuccess();
+      } catch (err) {
+        console.error(err);
+        toast.error(t('error.move'));
+      }
+    },
+    collect: monitor => ({
+      isOver: monitor.isOver({ shallow: true }),
+      canDrop: monitor.canDrop(),
+    }),
+  });
+
+  drag(drop(ref));
+
   const icon = type === ItemType.FOLDER
-  ? faFolder
-  : selectFileIcon(item.name);
+    ? faFolder
+    : selectFileIcon(item.name);
 
   return (
     <div
@@ -23,14 +57,14 @@ const ItemCard = ({
         e.preventDefault();
         onContextMenu(e, item);
       }}
-      draggable
-      onDragStart={e => onDragStart(e, item)}
+      style={{
+        opacity: isDragging ? 0.5 : 1,
+        background: isOver && canDrop ? 'rgba(0, 123, 255, 0.1)' : '',
+        cursor: 'move'
+      }}
+      ref={ref}
     >
-      <FontAwesomeIcon
-        icon={icon}
-        size="4x"
-        className="mb-3"
-      />
+      <FontAwesomeIcon icon={icon} size="4x" className="mb-3" />
       <span
         className="file-name text-truncate"
         title={getDisplayName(item.name)}

--- a/ui/src/components/DashboardComponents/DeleteFile/DeleteFile.jsx
+++ b/ui/src/components/DashboardComponents/DeleteFile/DeleteFile.jsx
@@ -33,6 +33,8 @@ const DeleteItem = ({ item, setIsDeleteItemModalOpen, setTargetItem }) => {
         confirmText={t('delete')}
         onConfirm={handleDelete}
         onCancel={() => setIsDeleteItemModalOpen(false)}
+        cancelColor={'secondary'}
+        confirmColor={'danger'}
       >
       <p>{t('delete.message.1')}&nbsp;<em>{item.name}</em>{t('delete.message.2')}</p>
     </FormModal>

--- a/ui/src/components/DashboardComponents/DeleteFile/DeleteFile.jsx
+++ b/ui/src/components/DashboardComponents/DeleteFile/DeleteFile.jsx
@@ -20,7 +20,7 @@ const DeleteItem = ({ item, setIsDeleteItemModalOpen, setTargetItem }) => {
     const data = {
       path: item.path,
       name: item.name,
-      type: getType(item.name),
+      type: getItemType(item.name, userFolders),
     };
     dispatch(deleteItem(data));
     setIsDeleteItemModalOpen(false);

--- a/ui/src/components/DashboardComponents/FolderComponent/FolderComponent.jsx
+++ b/ui/src/components/DashboardComponents/FolderComponent/FolderComponent.jsx
@@ -1,7 +1,5 @@
 import { useTranslation } from "react-i18next";
 import { shallowEqual, useSelector } from "react-redux";
-import { DndProvider } from "react-dnd";
-import { HTML5Backend } from "react-dnd-html5-backend";
 
 import ShowItems from "../ShowItems/ShowItems";
 import ItemType from "../../Types/itemType";
@@ -44,7 +42,6 @@ const FolderComponent = ({
   return (
     <div className="col-md-12 w-100">
       {hasFolders && (
-        <DndProvider backend={HTML5Backend}>
           <ShowItems
             title={t("folders")}
             type={ItemType.FOLDER}
@@ -56,10 +53,8 @@ const FolderComponent = ({
             setIsDeleteItemModalOpen={setIsDeleteItemModalOpen}
             setTargetItem={setTargetItem}
           />
-        </DndProvider>
       )}
       {hasFiles && (
-        <DndProvider backend={HTML5Backend}>
           <ShowItems
             title={t('files')}
             type={ItemType.FILE}
@@ -71,7 +66,6 @@ const FolderComponent = ({
             setIsDeleteItemModalOpen={setIsDeleteItemModalOpen}
             setTargetItem={setTargetItem}
           />
-        </DndProvider>
       )}
     </div>
   )

--- a/ui/src/components/DashboardComponents/FolderComponent/FolderComponent.jsx
+++ b/ui/src/components/DashboardComponents/FolderComponent/FolderComponent.jsx
@@ -1,5 +1,8 @@
 import { useTranslation } from "react-i18next";
 import { shallowEqual, useSelector } from "react-redux";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+
 import ShowItems from "../ShowItems/ShowItems";
 import ItemType from "../../Types/itemType";
 
@@ -10,11 +13,12 @@ const FolderComponent = ({
   setIsDeleteItemModalOpen,
   setTargetItem 
 }) => {
-  const { userFolders, userFiles, isLoading } = useSelector(
+  const { userFolders, userFiles, isLoading, currentFolder } = useSelector(
     state => ({ 
       userFolders: state.fileFolders.userFolders,
       userFiles: state.fileFolders.userFiles,
       isLoading: state.fileFolders.isLoading,
+      currentFolder: state.fileFolders.currentFolder,
     }), shallowEqual);
   const { t } = useTranslation();
 
@@ -40,28 +44,34 @@ const FolderComponent = ({
   return (
     <div className="col-md-12 w-100">
       {hasFolders && (
-        <ShowItems
-          title={t("folders")}
-          type={ItemType.FOLDER}
-          items={userFolders}
-          onPreview={onPreview}
-          onNoPreview={onNoPreview}
-          setIsRenameItemModalOpen={setIsRenameItemModalOpen}
-          setIsDeleteItemModalOpen={setIsDeleteItemModalOpen}
-          setTargetItem={setTargetItem}
-        />
+        <DndProvider backend={HTML5Backend}>
+          <ShowItems
+            title={t("folders")}
+            type={ItemType.FOLDER}
+            items={userFolders}
+            currentFolder={currentFolder}
+            onPreview={onPreview}
+            onNoPreview={onNoPreview}
+            setIsRenameItemModalOpen={setIsRenameItemModalOpen}
+            setIsDeleteItemModalOpen={setIsDeleteItemModalOpen}
+            setTargetItem={setTargetItem}
+          />
+        </DndProvider>
       )}
       {hasFiles && (
-        <ShowItems
-          title={t('files')}
-          type={ItemType.FILE}
-          items={userFiles}
-          onPreview={onPreview}
-          onNoPreview={onNoPreview}
-          setIsRenameItemModalOpen={setIsRenameItemModalOpen}
-          setIsDeleteItemModalOpen={setIsDeleteItemModalOpen}
-          setTargetItem={setTargetItem}
-        />
+        <DndProvider backend={HTML5Backend}>
+          <ShowItems
+            title={t('files')}
+            type={ItemType.FILE}
+            items={userFiles}
+            currentFolder={currentFolder}
+            onPreview={onPreview}
+            onNoPreview={onNoPreview}
+            setIsRenameItemModalOpen={setIsRenameItemModalOpen}
+            setIsDeleteItemModalOpen={setIsDeleteItemModalOpen}
+            setTargetItem={setTargetItem}
+          />
+        </DndProvider>
       )}
     </div>
   )

--- a/ui/src/components/DashboardComponents/RenameFile/RenameFile.jsx
+++ b/ui/src/components/DashboardComponents/RenameFile/RenameFile.jsx
@@ -52,7 +52,7 @@ const RenameItem = ({ item, setIsRenameItemModalOpen, setRenameItem }) => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    const type = getType(item.name);
+    const type = getItemType(item.name, userFolders);
     if (newName) {
       if (newName.length >= 3) {
         const fullname = getFullName(newName);

--- a/ui/src/components/DashboardComponents/ShowItems/ShowItems.jsx
+++ b/ui/src/components/DashboardComponents/ShowItems/ShowItems.jsx
@@ -1,28 +1,26 @@
-import { useNavigate }  from 'react-router-dom';
-import { useDispatch }  from 'react-redux';
+import { getFolders, getFiles } from '../../../redux/actionCreators/fileFoldersActionCreator';
 
-import ItemType         from '../../Types/itemType';
-import ContextMenu      from '../ContextMenu/ContextMenu';
 import './ShowItems.css';
-import { changeFolder, downloadFile } from '../../../redux/actionCreators/fileFoldersActionCreator';
-import { getFileExt,
-         getPreviewType }     from '../../../utils/filePreviewUtils';
+import ContextMenu      from '../ContextMenu/ContextMenu';
 import ItemCard from '../../Common/ItemCard/ItemCard';
 import useContextMenu from '../../../hooks/useContextMenu';
 import useItemActions from '../../../hooks/useItemActions';
 import ContextAction from '../../../enum/contextAction';
+import { useDispatch } from 'react-redux';
 
 
 const ShowItems = ({ 
   title, 
   items, 
   type, 
+  currentFolder,
   onPreview, 
   onNoPreview, 
   setIsRenameItemModalOpen, 
   setIsDeleteItemModalOpen,
   setTargetItem,
 }) => {
+  const dispatch = useDispatch();
   const { open, current, anchorPoint, onContextMenu, closeMenu } = useContextMenu();
   const { getDisplayName, openItem, onContextAction } = useItemActions({
     onPreview,
@@ -32,8 +30,9 @@ const ShowItems = ({
     openDeleteModal: () => setIsDeleteItemModalOpen(true),
   });
 
-  const handleDragStart = (e, item) => {
-    console.log("Drag")
+  const fetchItems = (path) => {
+    dispatch(getFolders(path));
+    dispatch(getFiles(path));
   }
 
   return (
@@ -48,8 +47,8 @@ const ShowItems = ({
             type={type}
             onDoubleClick={() => openItem(item)}
             onContextMenu={e => onContextMenu(e, item)}
-            onDragStart={handleDragStart}
             getDisplayName={getDisplayName}
+            onDropSuccess={() => fetchItems(currentFolder)}
           />
         ))}
       </div>

--- a/ui/src/components/DashboardComponents/ShowItems/ShowItems.jsx
+++ b/ui/src/components/DashboardComponents/ShowItems/ShowItems.jsx
@@ -1,4 +1,4 @@
-import { getFolders, getFiles } from '../../../redux/actionCreators/fileFoldersActionCreator';
+import { fetchItems } from '../../../utils/apiShortcuts';
 
 import './ShowItems.css';
 import ContextMenu      from '../ContextMenu/ContextMenu';
@@ -6,7 +6,6 @@ import ItemCard from '../../Common/ItemCard/ItemCard';
 import useContextMenu from '../../../hooks/useContextMenu';
 import useItemActions from '../../../hooks/useItemActions';
 import ContextAction from '../../../enum/contextAction';
-import { useDispatch } from 'react-redux';
 
 
 const ShowItems = ({ 
@@ -20,7 +19,6 @@ const ShowItems = ({
   setIsDeleteItemModalOpen,
   setTargetItem,
 }) => {
-  const dispatch = useDispatch();
   const { open, current, anchorPoint, onContextMenu, closeMenu } = useContextMenu();
   const { getDisplayName, openItem, onContextAction } = useItemActions({
     onPreview,
@@ -29,11 +27,6 @@ const ShowItems = ({
     openRenameModal: () => setIsRenameItemModalOpen(true),
     openDeleteModal: () => setIsDeleteItemModalOpen(true),
   });
-
-  const fetchItems = (path) => {
-    dispatch(getFolders(path));
-    dispatch(getFiles(path));
-  }
 
   return (
     <div className="w-100" onClick={closeMenu}>

--- a/ui/src/components/DashboardComponents/SubBar/SubBar.jsx
+++ b/ui/src/components/DashboardComponents/SubBar/SubBar.jsx
@@ -1,20 +1,25 @@
-import './SubBar.css';
 import { useTranslation } from 'react-i18next';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFileUpload, faFileAlt, faFolderPlus } from '@fortawesome/free-solid-svg-icons';
 import { useNavigate } from 'react-router-dom';
 import { shallowEqual, useSelector, useDispatch } from 'react-redux';
 import { changeFolder } from '../../../redux/actionCreators/fileFoldersActionCreator';
+import { getBreadcrumbSegment } from '../../../utils/breadcrumbUtils';
+import { fetchItems } from '../../../utils/apiShortcuts';
+
+import './SubBar.css';
+import BreadcrumbItem from '../../Common/BreadcrumbItem/BreadcumbItem';
+import useBreadcrumbDrop from '../../../hooks/useBreadcrumbDrops';
+
 
 const SubBar = ({ setIsCreateFolderModalOpen, setIsCreateFileModalOpen, setIsUploadFileModalOpen }) => {
   const { t }      = useTranslation();
   const navigate   = useNavigate();
   const dispatch   = useDispatch();
 
-  const { currentFolder, userFolders } = useSelector(
+  const { currentFolder } = useSelector(
     state => ({
       currentFolder: state.fileFolders.currentFolder,
-      userFolders:   state.fileFolders.userFolders
     }),
     shallowEqual
   );
@@ -27,55 +32,37 @@ const SubBar = ({ setIsCreateFolderModalOpen, setIsCreateFileModalOpen, setIsUpl
     dispatch(changeFolder(path))
 
     path === "/"
-    ? navigate(`/dashboard`)
-    : navigate(`/dashboard/folder/${param}`);
+      ? navigate(`/dashboard`)
+      : navigate(`/dashboard/folder/${param}`);
   };
 
-  const segments = currentFolder === "/" 
-    ? [] 
-    : currentFolder.split("/").filter(Boolean);
+  const segments = getBreadcrumbSegment(currentFolder);
+
+  const handleCrumbDrop = useBreadcrumbDrop(currentFolder, fetchItems);
 
   return (
     <nav className="navbar navbar-expand-lg mt-2 navbar-light bg-white py-2">
-      {/* Breadcrumbs */}
       <nav className="ms-5" aria-label="breadcrumb">
         <ol className="breadcrumb d-flex align-items-center">
-          {/* Root crumb */}
-          <li className="breadcrumb-item">
-            {currentFolder !== "/" ? (
-              <button 
-                className="btn btn-link p-0 text-decoration-none" 
-                onClick={() => handleNavigate("/")}
-              >
-                {t("root")}
-              </button>
-            ) : (
-              <span>{t("root")}</span>
-            )}
-          </li>
-
-          {/* Intermediate crumbs */}
+          <BreadcrumbItem
+            label={t('root')}
+            path="/"
+            isLast={currentFolder === '/'}
+            onNavigate={() => handleNavigate('/')}
+            onDrop={handleCrumbDrop}
+          />
           {segments.map((seg, idx) => {
-            const upTo = "/" + segments.slice(0, idx + 1).join("/");
+            const upTo = '/' + segments.slice(0, idx + 1).join('/');
             const isLast = idx === segments.length - 1;
-
             return (
-              <li 
-                key={upTo} 
-                className={`breadcrumb-item ${isLast ? "active" : ""}`}
-                aria-current={isLast ? "page" : undefined}
-              >
-                {isLast ? (
-                  seg
-                ) : (
-                  <button 
-                    className="btn btn-link p-0 text-decoration-none" 
-                    onClick={() => handleNavigate(upTo)}
-                  >
-                    {seg}
-                  </button>
-                )}
-              </li>
+              <BreadcrumbItem
+                key={upTo}
+                label={seg}
+                path={upTo}
+                isLast={isLast}
+                onNavigate={() => handleNavigate(upTo)}
+                onDrop={handleCrumbDrop}
+              />
             );
           })}
         </ol>

--- a/ui/src/hooks/useBreadcrumbDrops.js
+++ b/ui/src/hooks/useBreadcrumbDrops.js
@@ -1,0 +1,34 @@
+import { useCallback } from "react";
+import { toast } from "react-toastify";
+import { useDispatch } from "react-redux";
+import { changeFolder } from "../redux/actionCreators/fileFoldersActionCreator";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+
+import apiClient from "../utils/apiClient";
+
+function useBreadcrumbDrop(currentFolder, fetchItems) {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+
+  return useCallback(async (sourcePath, destFolder) => {
+    try {
+      await apiClient.moveItem(sourcePath, destFolder);
+      dispatch(changeFolder(destFolder));
+      const param = destFolder === '/'
+        ? ''
+        : encodeURIComponent(destFolder.replace(/^\//, ''));
+      navigate(destFolder === '/'
+        ? '/dashboard'
+        : `/dashboard/folder/${param}`);
+      fetchItems(destFolder);
+      toast.success(t('success.move'));
+    } catch (err) {
+      console.error(err);
+      toast.error(t('error.move'));
+    }
+  }, [currentFolder, dispatch, navigate, fetchItems, t]);
+}
+
+export default useBreadcrumbDrop;

--- a/ui/src/locales/en/common.json
+++ b/ui/src/locales/en/common.json
@@ -40,6 +40,7 @@
   "success.rename.folder": "Folder renamed successfully",
   "success.delete.file": "File deleted successfully",
   "success.delete.folder": "Folder deleted successfully",
+  "success.move": "Item moved successfully",
   "loading": "Loading...",
   "folder.empty": "There is nothing here yet...",
   "folders": "Folders",

--- a/ui/src/locales/en/common.json
+++ b/ui/src/locales/en/common.json
@@ -32,6 +32,7 @@
   "error.rename.folder": "Folder could not be renamed",
   "error.delete.file": "File could not be deleted",
   "error.delete.folder": "Folder could not be deleted",
+  "error.move": "Item could not be moved",
   "success.folder": "Folder created successfully",
   "success.file": "File created successfully",
   "success.upload": "Files uploaded successfully",

--- a/ui/src/locales/fr/common.json
+++ b/ui/src/locales/fr/common.json
@@ -33,6 +33,7 @@
   "error.rename.folder": "Le dossier n'a pas pu être renommé",
   "error.delete.file":   "Le fichier n'a pas pu être supprimé",
   "error.delete.folder": "Le dossier n'a pas pu être supprimé",
+  "error.move": "Impossible de déplacer l’élément",
   "success.folder": "Dossier créé avec succès",
   "success.file": "Fichier créé avec succès",
   "success.upload": "Fichiers téléversé avec succès",

--- a/ui/src/locales/fr/common.json
+++ b/ui/src/locales/fr/common.json
@@ -41,6 +41,7 @@
   "success.rename.folder": "Dossier renommé avec succès",
   "success.delete.file":   "Fichier supprimé avec succès",
   "success.delete.folder": "Dossier supprimé avec succès",
+  "success.move": "Élément déplacé avec succès",
   "loading": "En cours de chargement...",
   "folder.empty": "Il n'y a rien ici pour le moment...",
   "folders": "Dossiers",

--- a/ui/src/pages/DashboardPage/DashboardPage.jsx
+++ b/ui/src/pages/DashboardPage/DashboardPage.jsx
@@ -14,6 +14,8 @@ import PreviewModal from "../../components/DashboardComponents/Preview/PreviewMo
 import NoPreviewModal from "../../components/DashboardComponents/Preview/NoPreviewModal";
 import RenameItem from "../../components/DashboardComponents/RenameFile/RenameFile";
 import DeleteItem from "../../components/DashboardComponents/DeleteFile/DeleteFile";
+import { DndProvider } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
 
 const DashboardPage = () => {
   const [isCreateFolderModalOpen, setIsCreateFolderModalOpen] = useState(false);
@@ -70,31 +72,33 @@ const DashboardPage = () => {
         />
       )}
       <Navbar />
-      <SubBar
-        setIsCreateFolderModalOpen={setIsCreateFolderModalOpen}
-        setIsCreateFileModalOpen={setIsCreateFileModalOpen}
-        setIsUploadFileModalOpen={setIsUploadFileModalOpen}
-      />
+      <DndProvider backend={HTML5Backend}>
+        <SubBar
+          setIsCreateFolderModalOpen={setIsCreateFolderModalOpen}
+          setIsCreateFileModalOpen={setIsCreateFileModalOpen}
+          setIsUploadFileModalOpen={setIsUploadFileModalOpen}
+        />
 
-      <Routes>
-        <Route index element={<FolderComponent 
-          onPreview={(f, type) => setPreview({file: f, type})} 
-          onNoPreview={f => setNoPreview(f)}
-          setIsRenameItemModalOpen={setIsRenameItemModalOpen}
-          setIsDeleteItemModalOpen={setIsDeleteItemModalOpen}
-          setTargetItem={setTargetItem}
-        />} />
-        <Route
-          path="folder/:folderId"
-          element={<FolderComponent 
+        <Routes>
+          <Route index element={<FolderComponent 
             onPreview={(f, type) => setPreview({file: f, type})} 
             onNoPreview={f => setNoPreview(f)}
             setIsRenameItemModalOpen={setIsRenameItemModalOpen}
             setIsDeleteItemModalOpen={setIsDeleteItemModalOpen}
             setTargetItem={setTargetItem}
-          />}
-        />
-      </Routes>
+          />} />
+          <Route
+            path="folder/:folderId"
+            element={<FolderComponent 
+              onPreview={(f, type) => setPreview({file: f, type})} 
+              onNoPreview={f => setNoPreview(f)}
+              setIsRenameItemModalOpen={setIsRenameItemModalOpen}
+              setIsDeleteItemModalOpen={setIsDeleteItemModalOpen}
+              setTargetItem={setTargetItem}
+            />}
+          />
+        </Routes>
+      </DndProvider>
     </>
   );
 };

--- a/ui/src/utils/apiClient.js
+++ b/ui/src/utils/apiClient.js
@@ -29,6 +29,9 @@ const apiClient = {
 
   deleteItem: (path) =>
     axios.delete('/api/delete', { params: { path } }),
+
+  moveItem: (sourcePath, destPath) =>
+    axios.post('/api/move', { sourcePath, destPath }),
 };
 
 export default apiClient;

--- a/ui/src/utils/apiShortcuts.js
+++ b/ui/src/utils/apiShortcuts.js
@@ -1,0 +1,6 @@
+import apiClient from "./apiClient";
+
+export function fetchItems(path) {
+  apiClient.getFolders(path);
+  apiClient.getFiles(path);
+}

--- a/ui/src/utils/breadcrumbUtils.js
+++ b/ui/src/utils/breadcrumbUtils.js
@@ -1,0 +1,5 @@
+export function getBreadcrumbSegment(currentFolder) {
+  return currentFolder === "/"
+    ? []
+    : currentFolder.split("/").filter(Boolean);
+}

--- a/ui/src/utils/pathUtils.js
+++ b/ui/src/utils/pathUtils.js
@@ -1,0 +1,5 @@
+export function isDescendant(srcPath, destPath) {
+  const src = srcPath.replace(/\/$/, '') + '/';
+  const dest = destPath.replace(/\/$/, '') + '/';
+  return dest.startsWith(src);
+}

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -4,6 +4,12 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  optimizeDeps: {
+    include: [
+      'react-dnd',
+      'react-dnd-html5-backend'
+    ],
+  },
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
# Drag & Drop moves + Breadcrumb drop targets

## Summary

Adds Google-Drive–style drag-and-drop to move files/folders, plus breadcrumb drop targets to move “up” into any ancestor folder. Includes backend `/api/move` endpoint, UI polish (custom drag preview, toasts), and guards to prevent illegal moves.

## What’s included

* **UI**

  * Wrap dashboard in `<DndProvider>` (HTML5 backend).
  * `ItemCard`: `useDrag` for all items; `useDrop` on folders; dim while dragging; highlight valid targets.
  * **Breadcrumb DnD**: each crumb is a drop target (root included, active crumb guarded).
  * Optional **CustomDragLayer** for a ghost preview following the cursor.
  * Success/error toasts: `move.success`, `error.move`.
  * A11y: cursor + keyboard open preserved; drag state via `opacity`.

* **Backend**

  * `POST /api/move` to move an item into a destination folder.
  * Path safety + basic validation (dest exists & is a directory).
  * (If implemented) server-side guard against self/descendant moves.

* **Utils/Hooks**

  * `useBreadcrumbDrop(currentFolder[, fetchItems])` to centralize move + refresh + navigation.
  * `breadcrumbUtils.getBreadcrumbSegment(path)` for crumb segments.
  * `pathUtils.isDescendant(src, dst)` guard used by UI (and server, if added).

* **i18n**

  * `move.success`: “Moved successfully”
  * `error.move`: “Could not move item”
  * (FR: `« Déplacement réussi »`, `« Impossible de déplacer l’élément »`)

## Not included / Intentional choices

* **No “root canvas” drop** (dropping in blank space) to avoid no-op API calls.
* Cross-window/tab drag is **not** supported (would require native HTML5 DnD).

## How to test

1. Drag a **file → sibling folder**; expect toast + refreshed list.
2. Drag a **folder → sibling folder**.
3. Drag a **file/folder → ancestor** via breadcrumb.
4. Try illegal moves (folder into itself / descendant) → should be blocked client-side (and server-side if enabled).
5. Verify download/rename/delete still function.
6. Dev CORS: Vite origin (`http://localhost:5173`) allowed.

## Edge cases handled

* Prevent self/descendant drops (`isDescendant`).
* Guard duplicate root drops (active crumb isn’t a target).
* Busy-state prevents double drop (if added).

## Release notes

* You can now drag items onto folders or breadcrumb segments to move them. Backend exposes `/api/move`.

## Checklist

* [x] i18n strings present in all locales
* [x] CORS allows dev origin(s)
* [x] Tests/manual pass for file + folder moves
* [x] Server name-conflict policy confirmed (409 vs overwrite vs auto-rename)

**Ready to merge.**
