### PR TITLE
Onlyoffice integration

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.24-alpine AS build
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+# build just the main package in this directory
+RUN CGO_ENABLED=0 go build -o server .
+
+FROM gcr.io/distroless/base-debian12
+WORKDIR /app
+COPY --from=build /app/server /app/server
+EXPOSE 8081
+ENTRYPOINT ["/app/server"]

--- a/api/environment/environmentUtils.go
+++ b/api/environment/environmentUtils.go
@@ -1,0 +1,76 @@
+package environment
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	RootDir string = "ROOT_DIR"
+	OnlyOfficeJWTSecret string = "ONLYOFFICE_JWT_SECRET"
+	ApiPublicUrl string = "API_PUBLIC_URL" 
+	AllowedOrigins string = "ALLOWED_ORIGINS"
+)
+
+func Getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" { return v }
+	return def
+}
+// ExpandPath expands "~", "$HOME", "${HOME}" (and %USERPROFILE% on Windows),
+// and turns relative paths into absolute ones rooted at the user's home dir.
+func ExpandPath(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return p
+	}
+	home, _ := os.UserHomeDir()
+
+	// env-style expansions
+	p = strings.ReplaceAll(p, "$HOME", home)
+	p = strings.ReplaceAll(p, "${HOME}", home)
+	if runtime.GOOS == "windows" {
+		if up := os.Getenv("USERPROFILE"); up != "" {
+			p = strings.ReplaceAll(p, "%USERPROFILE%", up)
+		}
+	}
+	// ~ expansion
+	if strings.HasPrefix(p, "~") {
+		p = filepath.Join(home, strings.TrimPrefix(p, "~"))
+	}
+	// relative -> $HOME/relative
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(home, p)
+	}
+	return filepath.Clean(p)
+}
+
+// Resolve a usable root dir (fallback: ~/HomeNest)
+func ResolveRootDir() string {
+	if v := os.Getenv(RootDir); v != "" {
+		return ExpandPath(v)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatalf("Could not get home directory: %v", err)
+	}
+	return filepath.Join(home, "HomeNest")
+}
+
+// Parse comma-separated env list (trims spaces, drops empties)
+func SplitCSVEnv(key string, def []string) []string {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if s := strings.TrimSpace(p); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/api/environment/environmentUtils.go
+++ b/api/environment/environmentUtils.go
@@ -9,18 +9,13 @@ import (
 )
 
 const (
-	RootDir string = "ROOT_DIR"
-	OnlyOfficeJWTSecret string = "ONLYOFFICE_JWT_SECRET"
-	ApiPublicUrl string = "API_PUBLIC_URL" 
-	AllowedOrigins string = "ALLOWED_ORIGINS"
+	RootDir             = "ROOT_DIR"
+	OnlyOfficeJWTSecret = "ONLYOFFICE_JWT_SECRET"
+	ApiPublicUrl        = "API_PUBLIC_URL"
+	AllowedOrigins      = "ALLOWED_ORIGINS"
 )
 
-func Getenv(key, def string) string {
-	if v := os.Getenv(key); v != "" { return v }
-	return def
-}
-// ExpandPath expands "~", "$HOME", "${HOME}" (and %USERPROFILE% on Windows),
-// and turns relative paths into absolute ones rooted at the user's home dir.
+// ExpandPath expands "~", $HOME, and turns relative into absolute (under $HOME)
 func ExpandPath(p string) string {
 	p = strings.TrimSpace(p)
 	if p == "" {

--- a/api/environment/environmentUtils.go
+++ b/api/environment/environmentUtils.go
@@ -13,6 +13,7 @@ const (
 	OnlyOfficeJWTSecret = "ONLYOFFICE_JWT_SECRET"
 	ApiPublicUrl        = "API_PUBLIC_URL"
 	AllowedOrigins      = "ALLOWED_ORIGINS"
+	OnlyOfficeURL				= "ONLYOFFICE_URL"
 )
 
 // ExpandPath expands "~", $HOME, and turns relative into absolute (under $HOME)

--- a/api/go.mod
+++ b/api/go.mod
@@ -7,4 +7,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 )
 
-require github.com/felixge/httpsnoop v1.0.3 // indirect
+require (
+	github.com/felixge/httpsnoop v1.0.3 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
+)

--- a/api/go.mod
+++ b/api/go.mod
@@ -3,11 +3,10 @@ module github.com/Sp0k/HomeNest/api
 go 1.24.4
 
 require (
+	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
+	github.com/joho/godotenv v1.5.1
 )
 
-require (
-	github.com/felixge/httpsnoop v1.0.3 // indirect
-	github.com/joho/godotenv v1.5.1 // indirect
-)
+require github.com/felixge/httpsnoop v1.0.3 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -4,3 +4,5 @@ github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyE
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,5 +1,7 @@
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=

--- a/api/handlers/FileNode.go
+++ b/api/handlers/FileNode.go
@@ -1,0 +1,16 @@
+package handlers
+
+import (
+	"time"
+)
+
+// FileNode is what we send back to the client to represent a file or folder.
+type FileNode struct {
+	Name string `json:"name"`
+	Path string `json:"path"` // relative to BaseDir, with forward‑slashes
+	IsDir bool `json:"isDir"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	LastAccessed *time.Time `json:"lastAccessed"`
+	CreatedBy string `json:"createdBy"`
+}

--- a/api/handlers/create_file.go
+++ b/api/handlers/create_file.go
@@ -15,7 +15,7 @@ type CreateFileRequest struct {
 	FileType string `json:"fileType"`
 }
 
-func CreateFileHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) CreateFileHandler(w http.ResponseWriter, r *http.Request) {
 	var req CreateFileRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid JSON payload", http.StatusBadRequest)
@@ -33,7 +33,7 @@ func CreateFileHandler(w http.ResponseWriter, r *http.Request) {
 		fullName = strings.Join([]string{req.FileName, req.FileType}, ".")
 	}
 
-	fullPath := filepath.Join(BaseDir, cleanParent, fullName)
+	fullPath := filepath.Join(s.BaseDir, cleanParent, fullName)
 
 	if _, err := os.Create(fullPath); err != nil {
 		http.Error(w, "Could not create folder: "+err.Error(),

--- a/api/handlers/create_folder.go
+++ b/api/handlers/create_folder.go
@@ -9,37 +9,14 @@ import (
 	"time"
 )
 
-// BaseDir is where all your files/folders live on disk.
-var BaseDir string
-
-func init() {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		panic("cannot determine user home directory: " + err.Error())
-	}
-	// TODO: add an installation process where the user can define their own path
-	BaseDir = filepath.Join(home, "Documents", "tests")
-}
-
 // CreateFolderRequest is the JSON payload we expect from the client.
 type CreateFolderRequest struct {
 	ParentPath string `json:"parentPath"`
 	FolderName string `json:"folderName"`
 }
 
-// FileNode is what we send back to the client to represent a file or folder.
-type FileNode struct {
-	Name string `json:"name"`
-	Path string `json:"path"` // relative to BaseDir, with forward‑slashes
-	IsDir bool `json:"isDir"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
-	LastAccessed *time.Time `json:"lastAccessed"`
-	CreatedBy string `json:"createdBy"`
-}
-
 // CreateFolderHandler handles POST /api/createFolder
-func CreateFolderHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) CreateFolderHandler(w http.ResponseWriter, r *http.Request) {
 	var req CreateFolderRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid JSON payload", http.StatusBadRequest)
@@ -52,7 +29,7 @@ func CreateFolderHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fullPath := filepath.Join(BaseDir, cleanParent, req.FolderName)
+	fullPath := filepath.Join(s.BaseDir, cleanParent, req.FolderName)
 
 	if err := os.MkdirAll(fullPath, 0755); err != nil {
 		http.Error(w, "Could not create folder: " + err.Error(),

--- a/api/handlers/delete_item.go
+++ b/api/handlers/delete_item.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func DeleteItemHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) DeleteItemHandler(w http.ResponseWriter, r *http.Request) {
 	p := r.URL.Query().Get("path")
 	clean := filepath.Clean(p)
 	if strings.Contains(clean, "..") {
@@ -15,7 +15,7 @@ func DeleteItemHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	abs := filepath.Join(BaseDir, clean)
+	abs := filepath.Join(s.BaseDir, clean)
 
 	info, err := os.Stat(abs)
 	if (err != nil) {

--- a/api/handlers/download_file.go
+++ b/api/handlers/download_file.go
@@ -5,11 +5,11 @@ import (
 	"path/filepath"
 )
 
-func DownloadHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) DownloadHandler(w http.ResponseWriter, r *http.Request) {
 	p := r.URL.Query().Get("path")
 
 	safe := filepath.Clean(p)
-	abs  := filepath.Join(BaseDir, safe)
+	abs  := filepath.Join(s.BaseDir, safe)
 
 	http.ServeFile(w, r, abs)
 }

--- a/api/handlers/get_files.go
+++ b/api/handlers/get_files.go
@@ -24,7 +24,7 @@ func isDirectoryFile(fileName string) bool {
 	return false
 }
 
-func GetFilesHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) GetFilesHandler(w http.ResponseWriter, r *http.Request) {
 	raw := r.URL.Query().Get("path")
 	if raw == "" {
 		raw = "/"
@@ -36,7 +36,7 @@ func GetFilesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fullPath := filepath.Join(BaseDir, cleanParent)
+	fullPath := filepath.Join(s.BaseDir, cleanParent)
 
 	entries, err := os.ReadDir(fullPath)
 	if err != nil {

--- a/api/handlers/get_folders.go
+++ b/api/handlers/get_folders.go
@@ -8,7 +8,7 @@ import (
     "strings"
 )
 
-func GetFoldersHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) GetFoldersHandler(w http.ResponseWriter, r *http.Request) {
     // 1️⃣ Read the `?path=` query parameter
     raw := r.URL.Query().Get("path")
     if raw == "" {
@@ -23,7 +23,7 @@ func GetFoldersHandler(w http.ResponseWriter, r *http.Request) {
     }
 
     // 3️⃣ Compute on‑disk directory
-    fullPath := filepath.Join(BaseDir, cleanParent)
+    fullPath := filepath.Join(s.BaseDir, cleanParent)
 
     // 4️⃣ Read the directory
     entries, err := os.ReadDir(fullPath)

--- a/api/handlers/move_file.go
+++ b/api/handlers/move_file.go
@@ -13,15 +13,15 @@ type MoveRequest struct {
 	DestPath 	 string `json:"destPath"`
 }
 
-func MoveHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) MoveHandler(w http.ResponseWriter, r *http.Request) {
 	var req MoveRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid request payload", http.StatusBadRequest)
 		return
 	}
 
-	srcFull := filepath.Join(BaseDir, filepath.Clean(req.SourcePath))
-	destDir := filepath.Join(BaseDir, filepath.Clean(req.DestPath))
+	srcFull := filepath.Join(s.BaseDir, filepath.Clean(req.SourcePath))
+	destDir := filepath.Join(s.BaseDir, filepath.Clean(req.DestPath))
 
 	info, err := os.Stat(destDir)
 	if err != nil {

--- a/api/handlers/onlyoffice.go
+++ b/api/handlers/onlyoffice.go
@@ -1,0 +1,274 @@
+package handlers
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"mime"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	env "github.com/Sp0k/HomeNest/api/environment"
+)
+
+type onlyofficeConfigReq struct {
+	Path string `json:"path"`
+	Mode string `json:"mode"`
+}
+
+func docTypeForExt(ext string) string {
+	e := strings.ToLower(ext)
+	switch e {
+	case ".docx", ".doc", ".odt", ".rtf", ".txt", ".html", ".docxf":
+		return "text"
+	case ".xlsx", ".xls", ".ods", ".csv":
+		return "spreadsheet"
+	case ".pptx", ".ppt", ".odp":
+		return "presentation"
+	default:
+		return "text"
+	}
+}
+
+func stableKey(abs string, fi os.FileInfo) string {
+	h := sha256.Sum256([]byte(abs + fi.ModTime().UTC().Format(time.RFC3339Nano)))
+	return hex.EncodeToString(h[:])
+}
+
+func (s *Server) baseURLForExternal(r *http.Request) string {
+	// Prefer explicit env (works in Docker compose: http://api:8081)
+	if v := os.Getenv(env.ApiPublicUrl); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	// Fallback to request host (works in local go run):
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return fmt.Sprintf("%s://%s", scheme, r.Host)
+}
+
+// POST /api/onlyoffice/config
+func (s *Server) OnlyOfficeConfigHandler(w http.ResponseWriter, r *http.Request) {
+	var req onlyofficeConfigReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad payload", http.StatusBadRequest)
+		return
+	}
+	rel := filepath.Clean("/" + req.Path)
+	abs := filepath.Join(s.BaseDir, rel)
+
+	if rel2, err := filepath.Rel(s.BaseDir, abs); err != nil || strings.HasPrefix(rel2, "..") {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	fi, err := os.Stat(abs)
+	if err != nil || fi.IsDir() {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+
+	secret := os.Getenv(env.OnlyOfficeJWTSecret)
+	base := s.baseURLForExternal(r)
+
+	// short-lived signed download URL (DS will GET this)
+	dlClaims := jwt.MapClaims{
+		"path": req.Path,
+		"exp":  time.Now().Add(10 * time.Minute).Unix(),
+	}
+	dlSig, _ := jwt.NewWithClaims(jwt.SigningMethodHS256, dlClaims).SignedString([]byte(secret))
+	downloadURL := base + "/api/files?path=" + url.QueryEscape(req.Path) + "&sig=" + url.QueryEscape(dlSig)
+
+	// callback (DS will POST here on save), include ?path so we know which file
+	callbackURL := base + "/api/onlyoffice/callback?path=" + url.QueryEscape(req.Path)
+
+	ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(abs)), ".")
+	unsignedCfg := map[string]any{
+		"document": map[string]any{
+			"fileType": ext,
+			"title":    filepath.Base(abs),
+			"key":      stableKey(abs, fi),
+			"url":      downloadURL,
+		},
+		"documentType": docTypeForExt(filepath.Ext(abs)),
+		"width":  "100%",
+		"height": "100%",
+		"editorConfig": map[string]any{
+			"mode":        map[bool]string{true: "edit", false: "view"}[strings.ToLower(req.Mode) != "view"],
+			"callbackUrl": callbackURL,
+			"customization": map[string]any{
+				"autosave": true,
+			},
+		},
+		"permissions": map[string]any{
+			"edit":     strings.ToLower(req.Mode) != "view",
+			"download": true,
+			"chat": 		true,
+		},
+	}
+
+
+	// Sign the *config itself* (no "payload" wrapper)
+	tokenStr, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(unsignedCfg)).
+		SignedString([]byte(secret))
+	if err != nil {
+		http.Error(w, "sign error", http.StatusInternalServerError)
+		return
+	}
+
+	// attach the token and send
+	unsignedCfg["token"] = tokenStr
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(unsignedCfg)
+}
+
+// GET /api/files?path=...&sig=...
+func (s *Server) FilesDownloadHandler(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Query().Get("path")
+	sig := r.URL.Query().Get("sig")
+	secret := os.Getenv(env.OnlyOfficeJWTSecret)
+	// verify sig
+	_, err := jwt.Parse(sig, func(t *jwt.Token) (any, error) { return []byte(secret), nil })
+	if err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	rel := filepath.Clean("/" + path)
+	abs := filepath.Join(s.BaseDir, rel)
+
+	if rel2, err := filepath.Rel(s.BaseDir, abs); err != nil || strings.HasPrefix(rel2, "..") {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	f, err := os.Open(abs)
+	if err != nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	defer f.Close()
+	fi, _ := f.Stat()
+
+	ctype := mime.TypeByExtension(strings.ToLower(filepath.Ext(abs)))
+	if ctype == "" {
+		buf := make([]byte, 512)
+		n, _ := f.Read(buf)
+		f.Seek(0, io.SeekStart)
+		ctype = http.DetectContentType(buf[:n])
+	}
+	w.Header().Set("Content-Type", ctype)
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename="%s"`, filepath.Base(abs)))
+	w.Header().Set("Cache-Control", "private, no-cache, no-store")
+	// Let DS read the file bytes
+	http.ServeContent(w, r, filepath.Base(abs), fi.ModTime(), f)
+}
+
+type onlyofficeCallback struct {
+	Status int    `json:"status"`
+	Url    string `json:"url"` // DS gives URL to updated file
+}
+
+// POST /api/onlyoffice/callback?path=...
+func (s *Server) OnlyOfficeCallbackHandler(w http.ResponseWriter, r *http.Request) {
+	target := r.URL.Query().Get("path")
+	w.Header().Set("Content-Type", "application/json")
+
+	if target == "" {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"error":0}`))
+		return
+	}
+
+	// tiny JSON cap & content-type check
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB
+	if ct := r.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		http.Error(w, `{"error":1,"msg":"unsupported media type"}`, http.StatusUnsupportedMediaType)
+		return
+	}
+
+	var cb onlyofficeCallback
+	if err := json.NewDecoder(r.Body).Decode(&cb); err != nil {
+		http.Error(w, `{"error":1,"msg":"bad payload"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Only save on statuses 2, 6, 7
+	if cb.Status != 2 && cb.Status != 6 && cb.Status != 7 {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"error":0}`))
+		return
+	}
+
+	// Path safety: stay under BaseDir
+	rel := filepath.Clean("/" + target)
+	abs := filepath.Join(s.BaseDir, rel)
+	if rel2, err := filepath.Rel(s.BaseDir, abs); err != nil || strings.HasPrefix(rel2, "..") {
+		http.Error(w, `{"error":1,"msg":"forbidden"}`, http.StatusForbidden)
+		return
+	}
+
+	// Verify updated file URL comes from YOUR Document Server
+	dsBase := strings.TrimRight(os.Getenv(env.OnlyOfficeURL), "/") // e.g. http://docs:80 or https://docs.example.com
+	if dsBase == "" {
+		http.Error(w, `{"error":1,"msg":"ONLYOFFICE_URL not set"}`, http.StatusInternalServerError)
+		return
+	}
+	u, err := url.Parse(cb.Url)
+	if err != nil || !strings.HasPrefix(cb.Url, dsBase+"/") {
+		http.Error(w, `{"error":1,"msg":"bad upstream"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Fetch updated file with timeout and soft size guard
+	secret := os.Getenv(env.OnlyOfficeJWTSecret)
+	authTok, _ := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"payload": map[string]any{},
+	}).SignedString([]byte(secret))
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	req, _ := http.NewRequest("GET", u.String(), nil)
+	req.Header.Set("Authorization", "Bearer "+authTok)
+
+	resp, err := client.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		if resp != nil { resp.Body.Close() }
+		http.Error(w, `{"error":1,"msg":"pull failed"}`, http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Optional soft cap (tune or remove as you wish)
+	if resp.ContentLength > 0 && resp.ContentLength > 100<<20 { // 100 MB
+		http.Error(w, `{"error":1,"msg":"file too large"}`, http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	tmp := abs + ".tmp"
+	out, err := os.Create(tmp)
+	if err != nil {
+		http.Error(w, `{"error":1,"msg":"write failed"}`, http.StatusInternalServerError)
+		return
+	}
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		out.Close()
+		_ = os.Remove(tmp)
+		http.Error(w, `{"error":1,"msg":"write failed"}`, http.StatusInternalServerError)
+		return
+	}
+	out.Close()
+	_ = os.Rename(tmp, abs)
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"error":0}`))
+}
+

--- a/api/handlers/rename_item.go
+++ b/api/handlers/rename_item.go
@@ -15,7 +15,7 @@ type RenameItemRequest struct {
 	Type string `json:"type"`
 }
 
-func RenameItemHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) RenameItemHandler(w http.ResponseWriter, r *http.Request) {
 	var req RenameItemRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid JSON payload", http.StatusBadRequest)
@@ -31,8 +31,8 @@ func RenameItemHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newPath := filepath.Join(BaseDir, cleanParent, req.NewName)
-	currPath := filepath.Join(BaseDir, cleanParent, req.CurrName)
+	newPath := filepath.Join(s.BaseDir, cleanParent, req.NewName)
+	currPath := filepath.Join(s.BaseDir, cleanParent, req.CurrName)
 
 	if err := os.Rename(currPath, newPath); err != nil {
 		http.Error(w, "Could not rename item" + err.Error(), http.StatusInternalServerError)

--- a/api/handlers/server.go
+++ b/api/handlers/server.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	env "github.com/Sp0k/HomeNest/api/environment"
@@ -15,9 +16,11 @@ func NewServer(baseDir string) (*Server, error) {
 	expanded := env.ExpandPath(baseDir)
 	if err := os.MkdirAll(expanded, 0755); err != nil {
 		return nil, fmt.Errorf(
-			"failed to create ROOT_DIR at %s: %w\nTip: set ROOT_DIR to a writable path like ~/HomeNest or ~/Documents/HomeNest in api/.env",
+			"failed to create ROOT_DIR at %s: %w\nTip: set ROOT_DIR to a writable path like ~/HomeNest or ~/Documents/HomeNest in .env",
 			expanded, err,
 		)
 	}
+	log.Printf("Using ROOT_DIR: %s", expanded)
 	return &Server{BaseDir: expanded}, nil
 }
+

--- a/api/handlers/server.go
+++ b/api/handlers/server.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"fmt"
+	"os"
+
+	env "github.com/Sp0k/HomeNest/api/environment"
+)
+
+type Server struct {
+	BaseDir string
+}
+
+func NewServer(baseDir string) (*Server, error) {
+	expanded := env.ExpandPath(baseDir)
+	if err := os.MkdirAll(expanded, 0755); err != nil {
+		return nil, fmt.Errorf(
+			"failed to create ROOT_DIR at %s: %w\nTip: set ROOT_DIR to a writable path like ~/HomeNest or ~/Documents/HomeNest in api/.env",
+			expanded, err,
+		)
+	}
+	return &Server{BaseDir: expanded}, nil
+}

--- a/api/handlers/upload_file.go
+++ b/api/handlers/upload_file.go
@@ -11,7 +11,7 @@ import (
 
 const uploadLimit = 500 << 20 // 500 MiB
 
-func UploadFileHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) UploadFileHandler(w http.ResponseWriter, r *http.Request) {
   r.Body = http.MaxBytesReader(w, r.Body, uploadLimit)
   if err := r.ParseMultipartForm(uploadLimit); err != nil {
     http.Error(w, "Could not parse multipart form: "+err.Error(), http.StatusBadRequest)
@@ -41,7 +41,7 @@ func UploadFileHandler(w http.ResponseWriter, r *http.Request) {
         return
       }
 
-      dstPath := filepath.Join(BaseDir, cleanParent, rel)
+      dstPath := filepath.Join(s.BaseDir, cleanParent, rel)
       if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
         in.Close()
         http.Error(w, "Could not create folder: "+err.Error(), http.StatusInternalServerError)

--- a/api/main.go
+++ b/api/main.go
@@ -46,5 +46,6 @@ func main() {
 	)
 
 	log.Println("API listening on http://localhost:8080")
+	log.Printf("Using ROOT_DIR: %s", srv.BaseDir)
 	log.Fatal(http.ListenAndServe(":8080", corsOpts(r)))
 }

--- a/api/main.go
+++ b/api/main.go
@@ -6,27 +6,43 @@ import (
 
   "github.com/gorilla/mux"
 	"github.com/gorilla/handlers"
+	"github.com/joho/godotenv"
 
+	env "github.com/Sp0k/HomeNest/api/environment"
 	nest "github.com/Sp0k/HomeNest/api/handlers"
 )
 
 func main() {
+	_ = godotenv.Load(".env") // OK if missing (Docker/production)
+
+	baseDir := env.ResolveRootDir()
+	srv, err := nest.NewServer(baseDir)
+	if err != nil { log.Fatalf("%v", err) }
+
 	r := mux.NewRouter()
 
-	r.HandleFunc("/api/createFolder", nest.CreateFolderHandler).Methods("POST")
-	r.HandleFunc("/api/getFolders", nest.GetFoldersHandler).Methods("GET")
-	r.HandleFunc("/api/getFiles", nest.GetFilesHandler).Methods("GET")
-	r.HandleFunc("/api/createFile", nest.CreateFileHandler).Methods("POST")
-	r.HandleFunc("/api/upload", nest.UploadFileHandler).Methods("POST")
-	r.HandleFunc("/api/download", nest.DownloadHandler).Methods("GET")
-	r.HandleFunc("/api/rename", nest.RenameItemHandler).Methods("POST")
-	r.HandleFunc("/api/delete", nest.DeleteItemHandler).Methods("DELETE")
-	r.HandleFunc("/api/move", nest.MoveHandler).Methods("POST")
+	r.HandleFunc("/api/createFolder", srv.CreateFolderHandler).Methods("POST")
+	r.HandleFunc("/api/getFolders", srv.GetFoldersHandler).Methods("GET")
+	r.HandleFunc("/api/getFiles", srv.GetFilesHandler).Methods("GET")
+	r.HandleFunc("/api/createFile", srv.CreateFileHandler).Methods("POST")
+	r.HandleFunc("/api/upload", srv.UploadFileHandler).Methods("POST")
+	r.HandleFunc("/api/download", srv.DownloadHandler).Methods("GET")
+	r.HandleFunc("/api/rename", srv.RenameItemHandler).Methods("POST")
+	r.HandleFunc("/api/delete", srv.DeleteItemHandler).Methods("DELETE")
+	r.HandleFunc("/api/move", srv.MoveHandler).Methods("POST")
+
+	// CORS origins from env (comma-separated), with sensible defaults for dev
+	defaultOrigins := []string{
+		"http://localhost:5173", "http://127.0.0.1:5173", // Vite
+		"http://localhost:3000", "http://127.0.0.1:3000", // CRA (if you use it)
+		"http://localhost:8080", "http://127.0.0.1:8080", // OnlyOffice DS or API (dev)
+	}
+	origins := env.SplitCSVEnv(env.AllowedOrigins, defaultOrigins)
 
 	corsOpts := handlers.CORS(
-		handlers.AllowedOrigins([]string{"http://localhost:3000"}),
+		handlers.AllowedOrigins(origins),
 		handlers.AllowedMethods([]string{"GET", "POST", "DELETE", "PUT", "OPTIONS"}),
-		handlers.AllowedHeaders([]string{"Content-type"}),
+		handlers.AllowedHeaders([]string{"Content-Type", "Authorization"}),
 	)
 
 	log.Println("API listening on http://localhost:8080")

--- a/api/main.go
+++ b/api/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 func main() {
-	_ = godotenv.Load(".env") // OK if missing (Docker/production)
+	_ = godotenv.Load("../.env", ".env") // OK if missing (Docker/production)
 
 	baseDir := env.ResolveRootDir()
 	srv, err := nest.NewServer(baseDir)
@@ -45,7 +45,7 @@ func main() {
 		handlers.AllowedHeaders([]string{"Content-Type", "Authorization"}),
 	)
 
-	log.Println("API listening on http://localhost:8080")
+	log.Println("API listening on http://localhost:8081")
 	log.Printf("Using ROOT_DIR: %s", srv.BaseDir)
-	log.Fatal(http.ListenAndServe(":8080", corsOpts(r)))
+	log.Fatal(http.ListenAndServe(":8081", corsOpts(r)))
 }

--- a/api/main.go
+++ b/api/main.go
@@ -30,6 +30,9 @@ func main() {
 	r.HandleFunc("/api/rename", srv.RenameItemHandler).Methods("POST")
 	r.HandleFunc("/api/delete", srv.DeleteItemHandler).Methods("DELETE")
 	r.HandleFunc("/api/move", srv.MoveHandler).Methods("POST")
+	r.HandleFunc("/api/onlyoffice/config", srv.OnlyOfficeConfigHandler).Methods("POST")
+	r.HandleFunc("/api/onlyoffice/callback", srv.OnlyOfficeCallbackHandler).Methods("POST")
+	r.HandleFunc("/api/files",              srv.FilesDownloadHandler).Methods("GET")
 
 	// CORS origins from env (comma-separated), with sensible defaults for dev
 	defaultOrigins := []string{
@@ -43,7 +46,7 @@ func main() {
 		handlers.AllowedOrigins(origins),
 		handlers.AllowedMethods([]string{"GET", "POST", "DELETE", "PUT", "OPTIONS"}),
 		handlers.AllowedHeaders([]string{"Content-Type", "Authorization"}),
-	)
+		)
 
 	log.Println("API listening on http://localhost:8081")
 	log.Printf("Using ROOT_DIR: %s", srv.BaseDir)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  api:
+    build: ./api
+    ports: ["8081:8081"]
+    environment:
+      - ROOT_DIR=/srv/homenest/data
+      - ONLYOFFICE_JWT_SECRET=${ONLYOFFICE_JWT_SECRET}
+      - API_PUBLIC_URL=http://api:8081
+      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
+    volumes:
+      - ${HOST_DATA_DIR:-${HOME}/HomeNest/data}:/srv/homenest/data
+
+  documentserver:
+    image: onlyoffice/documentserver:latest
+    ports: ["8080:80"]
+    environment:
+      - JWT_ENABLED=true
+      - JWT_SECRET=${ONLYOFFICE_JWT_SECRET}
+    depends_on: [api]

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -1,3 +1,5 @@
 body {
   overflow-x: hidden;
+  height: 100%;
+  margin: 0%;
 }

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -7,10 +7,10 @@ import './App.css'
 
 import HomePage from './pages/HomePage/HomePage'
 import DashboardPage from './pages/DashboardPage/DashboardPage'
+import OnlyOfficeEditor from "./pages/Editor/OnlyOfficeEditor"
 
 const App = () => {
   const { t, i18n } = useTranslation();
-
   useEffect(() => {
     document.title = t('title.page')
   }, [i18n.language]);
@@ -20,6 +20,7 @@ const App = () => {
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/dashboard/*" element={<DashboardPage />} />
+        <Route path="/editor" element={<OnlyOfficeEditor />} />
       </Routes>
       <ToastContainer />
     </div>

--- a/ui/src/pages/Editor/OnlyOfficeEditor.jsx
+++ b/ui/src/pages/Editor/OnlyOfficeEditor.jsx
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+
+const OnlyOfficeEditor = () => {
+  const containerRef = useRef(null);
+  const editorRef = useRef(null);
+  const [ready, setReady] = useState(false);
+
+  const { i18n } = useTranslation();
+  const params = new URLSearchParams(window.location.search);
+  const path = params.get('path');
+  const mode = params.get('mode') || 'edit';
+
+  // Load the Document Server script once
+  useEffect(() => {
+    const base = (import.meta.env.VITE_ONLYOFFICE_URL || '').replace(/\/+$/, '');
+    if (!base) { console.error('VITE_ONLYOFFICE_URL missing'); return; }
+    const s = document.createElement('script');
+    s.src = `${base}/web-apps/apps/api/documents/api.js`;
+    s.onload = () => setReady(true);
+    s.onerror = () => console.error('Failed to load OnlyOffice API script:', s.src);
+    document.body.appendChild(s);
+    return () => document.body.removeChild(s);
+  }, []);
+
+  // Init the editor
+  useEffect(() => {
+    if (!ready || !path || typeof window.DocsAPI === 'undefined') return;
+
+    const apiBase = (import.meta.env.VITE_API_BASE || '').replace(/\/+$/, '');
+    if (!apiBase) { console.error('VITE_API_BASE missing'); return; }
+
+    let cleanup = () => {};
+
+    (async () => {
+      const res = await fetch(`${apiBase}/api/onlyoffice/config`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path, mode }),
+      });
+      const text = await res.text();
+      if (!res.ok) { console.error('config failed', res.status, text); return; }
+      const cfg = JSON.parse(text);
+
+      const el = containerRef.current;
+      if (!el) return;
+      if (!el.id) el.id = 'onlyoffice-editor';
+
+      // Fill the container
+      cfg.height = `${window.innerHeight}px`;
+      cfg.lang = i18n.language || 'en';
+
+      editorRef.current = new window.DocsAPI.DocEditor(containerRef.current.id, cfg);
+
+      cleanup = () => {
+        try { editorRef.current?.destroyEditor?.(); } catch {}
+      };
+    })();
+
+    return () => cleanup();
+  }, [ready, path, mode]);
+
+  // Full-viewport container via portal
+  return createPortal(
+    <div
+      ref={containerRef}
+      id="placeholder"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        width: '100vw',
+        height: '100vh',
+        overflow: 'hidden',
+      }}
+    />,
+    document.body
+  );
+};
+
+export default OnlyOfficeEditor;

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -13,7 +13,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        target: 'http://localhost:8081',
         changeOrigin: true,
         secure: false,
       }


### PR DESCRIPTION
## ✨ OnlyOffice Integration

### Summary

This PR introduces full OnlyOffice integration for HomeNest, allowing users to open, edit, and save documents directly in the browser using a local Document Server instance.
The integration is designed for **local/LAN usage**, with JWT signing for requests and callbacks to ensure file integrity.

### Key Features

* **Document config endpoint**

  * Generates signed document configuration for the Document Server.
  * Includes autosave and mode handling (`edit` or `view`).
  * Detects file type to set `documentType` for OnlyOffice.

* **Secure file download endpoint**

  * Provides short-lived signed URLs for the Document Server to retrieve files.
  * Prevents directory traversal and validates MIME types.

* **Document save callback**

  * Handles POST requests from the Document Server when a document is saved.
  * Validates the file source, downloads updated file, and replaces the original.
  * Includes optional file size limits.

* **Frontend integration**

  * Embeds the OnlyOffice editor in a fullscreen portal.
  * Supports autosave without manual close prompts.
  * Displays a toast if the editor window is blocked by the browser.

### Notes

* Designed for LAN/VPN usage without heavy auth layers initially.
* JWT secret (`ONLYOFFICE_JWT_SECRET`) and Document Server URL must be set in `.env`.
* Popup blocking detection works in supported browsers.